### PR TITLE
Adding logout using sessions

### DIFF
--- a/auth/auth-router.js
+++ b/auth/auth-router.js
@@ -39,4 +39,18 @@ router.post('/login', (req, res) => {
     });
 });
 
+router.get('/logout', (req, res) => {
+  if (req.session) {
+    req.session.destroy(err => {
+      if (err) {
+        res.status(500).json({ message: 'Logout failed. Please try again later.' });
+      } else {
+        res.status(200).json({ message: 'Successfully logged out.' });
+      }
+    });
+  } else {
+    res.status(200).json({ message: 'You are already logged out.' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
#### What does this PR do?
It implements the functionality to log out a user with sessions.

#### Description of Task to be completed?
- Implement session logout.
- Test the implementation using postman

#### How should this be manually tested?
- *In postman*, log in with a POST request to the endpoint `http://localhost:3000/api/auth/login`, providing your `username` and `password` in the request body.
- Confirm that after a successful login that you have access to the resource GET `http://localhost:3000/api/users`
- Then log out by making a GET request to the endpoint `http://localhost:3000/api/users`;
- Now confirm that you no longer have access to the endpoint ``

#### Any background context you want to provide?
- I noticed that even after a successful logout if I make the request using HTTPie providing the login cookie as shown below, I still have access to the GET /users endpoint.
![image](https://user-images.githubusercontent.com/38833766/75393909-5f72ab80-58ef-11ea-9009-0727d6586ab7.png)


#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A